### PR TITLE
Added trust proxy setting to rate limiter

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const server = express()
 
 connect(() => console.log("📡 Database connection established"))
 
+server.set('trust proxy', 1)
 server.use(rateLimit({
     windowMs: 15 * 60 * 1000,
     max: 100


### PR DESCRIPTION
The app is hosted on heroku. Because heroku uses a reverse proxy we are hitting rate limits very quickly as the app considers all requests to be from the same IP address.
Adding this setting (as per the docs here - https://preview.npmjs.com/package/express-rate-limit) is intended to pass on the correct IP from the request to the app, which should stop the error. We will see!