### PR TITLE
Reword targetdirectory to match scout and be less prescriptive

### DIFF
--- a/controllers/index.js
+++ b/controllers/index.js
@@ -24,13 +24,14 @@ module.exports = {
 
       query.$and = []
 
-      // only get services for the specific scout instance
-      if (req.query.targetDirectories) {
-        let targetDirectoriesArray = [].concat(req.query.targetDirectories)
-        targetDirectoriesArray.forEach(cluster =>
+      // only get services for the requested target
+      if (req.query.targets) {
+        let targetsArray = [].concat(req.query.targets)
+        targetsArray.forEach(cluster => {
           query.$and.push({
             "target_directories.label": { $in: [].concat(cluster.split(",")) },
           })
+          }
         )
       }
 


### PR DESCRIPTION
Small change request.

I've done this just to distance ourselves from the word directory, since the target can and will be anything. Its more of a taxonomy. 

This change goes along with a PR in scout to follow!