### PR TITLE
Add in additional platforms for the outpost-api-image

### DIFF
--- a/.github/workflows/outpost-api-image.yml
+++ b/.github/workflows/outpost-api-image.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   push-outpost-api-image:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platforms: ["linux/amd64", "linux/arm64", "linux/arm64/v8"]
     steps:
       - name: "Checkout GitHub Action"
         uses: actions/checkout@main


### PR DESCRIPTION
Will now build for "linux/amd64", "linux/arm64", "linux/arm64/v8" not just "linux/amd64"