### PR TITLE
Optimise location query and sort orders

### DIFF
--- a/__tests__/unit/lib/filters.test.js
+++ b/__tests__/unit/lib/filters.test.js
@@ -1,8 +1,8 @@
 const filters = require("./../../../src/lib/filters")
 
-describe("locationGeometry", () => {
+describe("filterLocation", () => {
   it("should return an empty object if lat and lng are not provided", () => {
-    expect(filters.locationGeometry()).toEqual({})
+    expect(filters.filterLocation()).toEqual({})
   })
 
   it("should return a query object if lat and lng are provided", () => {
@@ -10,15 +10,33 @@ describe("locationGeometry", () => {
     const lng = "-74.0060"
     const expectedQuery = {
       "service_at_locations.location.geometry": {
-        $nearSphere: {
-          $geometry: {
-            type: "Point",
-            coordinates: [parseFloat(lng), parseFloat(lat)],
-          },
+        $geoWithin: {
+          $centerSphere: [[parseFloat(lng), parseFloat(lat)], 20 / 3963.2],
         },
       },
     }
-    expect(filters.locationGeometry(lat, lng)).toEqual(expectedQuery)
+    expect(filters.filterLocation(lat, lng, false)).toEqual(expectedQuery)
+  })
+
+  it("should return a different query object if lat and lng and keywordSearch are provided", () => {
+    const lat = "40.7128"
+    const lng = "-74.0060"
+    const expectedQuery = {
+      $or: [
+        {
+          "service_at_locations.location.geometry": {
+            $geoWithin: {
+              $centerSphere: [
+                [parseFloat(lng), parseFloat(lat)],
+                20 / 3963.2, // miles x 1609.34 = Distance in meters
+              ],
+            },
+          },
+        },
+        { "service_at_locations.location.geometry": { $exists: false } },
+      ],
+    }
+    expect(filters.filterLocation(lat, lng, true)).toEqual(expectedQuery)
   })
 })
 

--- a/__tests__/unit/v1/services/routes/get-services.test.js
+++ b/__tests__/unit/v1/services/routes/get-services.test.js
@@ -107,8 +107,8 @@ describe("get-services", () => {
         )
         expect(geocode).toHaveBeenCalledWith(queryParams.location)
         expect(interpreted_location).toEqual(results[0].formatted_address)
-        expect(lat).toBeCloseTo(parseInt(results[0].geometry.location.lat))
-        expect(lng).toBeCloseTo(parseInt(results[0].geometry.location.lng))
+        expect(lat).toBeCloseTo(parseFloat(results[0].geometry.location.lat))
+        expect(lng).toBeCloseTo(parseFloat(results[0].geometry.location.lng))
       })
 
       it("should return undefined if invalid location is provided", async () => {

--- a/src/controllers/v1/services/routes/get-services.js
+++ b/src/controllers/v1/services/routes/get-services.js
@@ -14,8 +14,8 @@ module.exports = {
     const page = parseInt(queryParams.page) || 1
     const keywords = queryParams.keywords
     const location = queryParams.location
-    let lat = parseFloat(queryParams.lat) || undefined
-    let lng = parseFloat(queryParams.lng) || undefined
+    let lat = queryParams?.lat ? parseFloat(queryParams.lat) : undefined
+    let lng = queryParams?.lng ? parseFloat(queryParams.lng) : undefined
     let directories = queryParams?.directories
       ? [].concat(queryParams.directories)
       : []
@@ -55,11 +55,10 @@ module.exports = {
     if (location && !(lat && lng)) {
       try {
         const { results } = await geocode(queryParams.location)
-        logger.debug(results)
         if (results[0]) {
           interpreted_location = results[0].formatted_address
-          lng = parseInt(results[0].geometry.location.lng)
-          lat = parseInt(results[0].geometry.location.lat)
+          lng = parseFloat(results[0].geometry.location.lng)
+          lat = parseFloat(results[0].geometry.location.lat)
         }
       } catch (error) {
         logger.warn(error)
@@ -94,21 +93,8 @@ module.exports = {
     let query = {}
     query.$and = []
 
-    const locationInQuery =
-      parameters.location !== undefined ||
-      parameters.lat !== undefined ||
-      parameters.lng !== undefined
-    const filterKeywords = await filters.filterKeywords(
-      parameters.keywords,
-      locationInQuery
-    )
+    const filterKeywords = await filters.filterKeywords(parameters.keywords)
     query = { ...filterKeywords, ...query }
-
-    const locationGeometry = filters.locationGeometry(
-      parameters.lat,
-      parameters.lng
-    )
-    query = { ...locationGeometry, ...query }
 
     // add filtering for ages
     const ages = filters.filterAges(parameters.minAge, parameters.maxAge)
@@ -124,6 +110,11 @@ module.exports = {
 
     // add filtering
     query.$and.push(
+      filters.filterLocation(
+        parameters.lat,
+        parameters.lng,
+        query?.$text ?? false
+      ),
       filters.filterDirectories(parameters.directories),
       filters.filterTaxonomies(parameters.taxonomies),
       filters.filterNeeds(parameters.needs),
@@ -139,37 +130,6 @@ module.exports = {
   },
 
   /**
-   * this is done because of the $nearSphere method in locationGeometry.
-   * This is because The $nearSphere operator cannot be used with the
-   * countDocuments() method in MongoDB because countDocuments()
-   * uses an aggregation pipeline under the hood, and $nearSphere is not
-   * allowed in an aggregation pipeline.
-   * so as a workaround if we're using nearsphere we update the count
-   * query to prevent errors
-   * the result of nearsphere will include all services with a location
-   * so this query is a good substitute to get the totalElements value
-   * @TODO test this doesn't affect query object
-   * http://localhost:3001/api/v1/services?lat=51.2107714&lng=0.31105&per_page=10&suitabilities=physical-disabilities
-   * @param {*} query
-   * @returns
-   */
-  createCountQuery: query => {
-    // "budget deep clone" we spread $and so can modify it for countQuery only
-    const countQuery = { ...query, $and: [...query.$and] }
-    if ("service_at_locations.location.geometry" in countQuery) {
-      delete countQuery["service_at_locations.location.geometry"]
-
-      countQuery["$and"].push({
-        "service_at_locations.location.geometry": {
-          $exists: true,
-          $ne: null,
-        },
-      })
-    }
-    return countQuery
-  },
-
-  /**
    *
    * @param {*} query
    * @param {*} perPage
@@ -178,14 +138,6 @@ module.exports = {
    */
   async executeQuery(query, perPage, page) {
     const Service = db().collection("indexed_services")
-    const countQuery = this.createCountQuery(query)
-
-    logger.debug("query")
-    logger.debug(query)
-    logger.debug(JSON.stringify(query))
-    logger.debug("countQuery")
-    logger.debug(countQuery)
-    logger.debug(JSON.stringify(countQuery))
 
     const queryProjection = query.$text
       ? {
@@ -196,16 +148,27 @@ module.exports = {
           ...projection,
         }
 
+    const sort = query.$text
+      ? {
+          score: { $meta: "textScore" },
+          updated_at: -1,
+        }
+      : {
+          updated_at: -1,
+        }
+
+    logger.debug("query")
+    logger.debug(query)
+    logger.debug(JSON.stringify(query))
+
     const [results, count] = await Promise.all([
       Service.find(query)
         .project(queryProjection)
-        .sort(
-          query.$text ? { score: { $meta: "textScore" } } : { updated_at: -1 }
-        )
+        .sort(sort)
         .limit(perPage)
         .skip((page - 1) * perPage)
         .toArray(),
-      Service.countDocuments(countQuery),
+      Service.countDocuments(query),
     ])
 
     return { results, count }

--- a/src/lib/filters.js
+++ b/src/lib/filters.js
@@ -1,32 +1,40 @@
 const { db } = require("../db")
+const logger = require("../../utils/logger")
 
 module.exports = {
-  locationGeometry: (lat, lng) => {
-    let query = {}
-    if (lat && lng) {
-      query["service_at_locations.location.geometry"] = {
-        // use this option to search within a defined area
-        // remember if you take out nearsphere to update the executeQuery function!
-        // this lets us get accurate result counts
-        // $geoWithin: {
-        //   $centerSphere: [
-        //     [parseFloat(lng), parseFloat(lat)],
-        //     10 / 3963.2, // 10 miles radius
-        //   ],
-        // },
-        // but this is how its always been done so we will keep this for now
-        // added maxDistance to limit the search to 15 miles for efficiency
-        // nb if you add in $maxDistance you will need to update the createCountQuery function workaround
-        $nearSphere: {
-          $geometry: {
-            type: "Point",
-            coordinates: [parseFloat(lng), parseFloat(lat)],
+  filterLocation: (lat, lng, keywordSearch) => {
+    if (lat !== undefined && lng !== undefined) {
+      logger.debug(
+        `Looking for services near ${parseFloat(lat)}, ${parseFloat(lng)} `
+      )
+      // if the query has keyword search then we need to make sure that we return services with no location still too
+      if (keywordSearch) {
+        return {
+          $or: [
+            {
+              "service_at_locations.location.geometry": {
+                $geoWithin: {
+                  $centerSphere: [
+                    [parseFloat(lng), parseFloat(lat)],
+                    20 / 3963.2, // miles x 1609.34 = Distance in meters
+                  ],
+                },
+              },
+            },
+            { "service_at_locations.location.geometry": { $exists: false } },
+          ],
+        }
+      } else {
+        return {
+          "service_at_locations.location.geometry": {
+            $geoWithin: {
+              $centerSphere: [[parseFloat(lng), parseFloat(lat)], 20 / 3963.2], // miles x 1609.34 = Distance in meters
+            },
           },
-          // $maxDistance: 10 * 1609.34, // miles x 1609.34 = Distance in meters
-        },
+        }
       }
     }
-    return query
+    return {}
   },
 
   visibleNow: () => {
@@ -51,18 +59,10 @@ module.exports = {
    * @param  {...any} args
    * @returns
    */
-  filterKeywords: async (keywords, locationInQuery = false) => {
+  filterKeywords: async keywords => {
     let query = {}
     if (keywords) {
-      if (locationInQuery) {
-        const Service = db().collection("indexed_services")
-        const docs = await Service.find({
-          $text: { $search: keywords },
-        }).toArray()
-        query._id = { $in: docs.map(doc => doc._id) }
-      } else {
-        query.$text = { $search: keywords }
-      }
+      query.$text = { $search: keywords }
     }
     return query
   },


### PR DESCRIPTION
Previously we did our location queries using `$nearSphere`

Pros:
- Return results from nearest to furthest.  

Cons:
- Slow
- Sort required another query to be done
- Keyword relevance wasn't taken into account so if you searched for a keyword that made no difference to the returned results order, they would always be in order from nearest to furthest with your keyword meaning very little
- it can't be used in an aggregation pipeline
- have to run the query again to get a count number

So we're now using `$geoWithin`

Pros:
- Faster: Searches within n miles of the spot but doesn't sort results so its faster
- If you're searching for keyword and location your keyword score ranks higher than nearest location - which makes more sense
- Can be run as an aggregation pipeline
- Count is included

Cons:
- results no longer sorted by nearest to furthest but a map view and future optional radius option will help with that


