### PR TITLE
Check to make sure the latest indexes are present

### DIFF
--- a/src/db.js
+++ b/src/db.js
@@ -27,6 +27,23 @@ module.exports = {
         } else {
           logger.info(`Connected to the "${dbName}" database`)
         }
+
+        // ensure that the location index exists
+        const indexName = "service_at_locations.location.geometry_2dsphere"
+        try {
+          const indexExists = await db
+            .collection("indexed_services")
+            .indexExists(indexName)
+
+          if (!indexExists) {
+            logger.warn(
+              `The index ${indexName} does not exist on your collection, please run prepare-indices script to create it or you will not return correct results.`
+            )
+          }
+        } catch (err) {
+          logger.error(`Unable to check for location index ${err}`)
+        }
+
         cb(db)
       })
       .catch(err => {


### PR DESCRIPTION
⚠️ Possible breaking change: ⚠️ 

When we switched over to `service_at_locations` we updated the indexes so when updating you will need to run

`npm run prepare-indices` 

or 

`db.indexed_services.createIndex({ "service_at_locations.location.geometry": "2dsphere" })`


You will also need to ensure that you have the latest version of Outpost running ⚠️ 
