### PR TITLE
fix for uncaught error

### DIFF
--- a/src/lib/filters.js
+++ b/src/lib/filters.js
@@ -342,10 +342,15 @@ const filters = {
                   const match = day.match(/(-?\d+)([A-Z]+)/)
                   return [match[1], match[2]]
                 })
-                options = {
-                  bysetpos: bysetpos[0][0],
-                  byweekday: RRule[bysetpos[0][1]],
-                  ...options,
+                const [firstBysetpos] = bysetpos || []
+                const [position, weekday] = firstBysetpos || []
+
+                if (position && weekday) {
+                  options = {
+                    bysetpos: parseInt(position),
+                    byweekday: RRule[weekday],
+                    ...options,
+                  }
                 }
               }
             }


### PR DESCRIPTION
We weren't parsing string to a number in the filters for weekdays - error: Error: bysetpos must be between 1 and 366, or between -366 and -1