### PR TITLE
Introduce rate limit option reduce default rate limit from 1000 to 100 per minute

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,9 @@ if (!isDevelopment) {
 server.use(
   rateLimit({
     windowMs: 1 * 60 * 1000, // 1 minute
-    max: 1000, // limit each IP to 1000 requests per windowMs
+    max: process.env.RATE_LIMIT ?? 100, // limit each IP to 100 requests per 1-minute window.
+    message: "Too many requests from this IP, please try again after a minute",
+    headers: true, // Include rate limit info in the response headers
   })
 )
 

--- a/readme.md
+++ b/readme.md
@@ -85,13 +85,14 @@ You can provide config with a `.env` file. Run `cp sample.env .env` to create a 
 
 The following environmental variables are required.
 
-| Variable         | Description                                                               | Example                                                              | Required? |
-| ---------------- | ------------------------------------------------------------------------- | -------------------------------------------------------------------- | --------- |
-| `DB_URI`         | Mongo database url                                                        | `mongodb://outpost:password@localhost:27018/outpost_api_development` | Yes       |
-| `GOOGLE_API_KEY` | Google API Key                                                            | `1234`                                                               | Yes       |
-| `DEBUG_LEVEL`    | Debug logging level options are: error, warn, info, http, debug           | `debug`                                                              | No        |
-| `FORCE_SSL`      | Force SSL defaults to false unless this is set to true                    | true                                                                 | No        |
-| `HOST_PORT`      | If running in docker set this to change the exposed port, default is 3000 | 3001                                                                 | No        |
+| Variable         | Description                                                                         | Example                                                              | Required? |
+| ---------------- | ----------------------------------------------------------------------------------- | -------------------------------------------------------------------- | --------- |
+| `DB_URI`         | Mongo database url                                                                  | `mongodb://outpost:password@localhost:27018/outpost_api_development` | Yes       |
+| `GOOGLE_API_KEY` | Google API Key                                                                      | `1234`                                                               | Yes       |
+| `DEBUG_LEVEL`    | Debug logging level options are: error, warn, info, http, debug                     | `debug`                                                              | No        |
+| `FORCE_SSL`      | Force SSL defaults to false unless this is set to true                              | true                                                                 | No        |
+| `HOST_PORT`      | If running in docker set this to change the exposed port, default is 3000           | 3001                                                                 | No        |
+| `RATE_LIMIT`     | Set this to change the number of requests allowed per minute per IP, default is 100 | 100                                                                  | No        |
 
 # ✨ Features
 


### PR DESCRIPTION
- Introduces new `RATE_LIMIT` env var
- Changes the default rate_limit to be `100` requests per second (previously `1000`) 